### PR TITLE
Handle placeholder strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ const processor = require('./processor')
 
 module.exports = (css, settings) => {
   const cssWithPlaceholders = css
-    .replace(/%%styled-jsx-(expression|placeholder)-(\d+)%%/g, (_, p, id) =>
-      `/*%%styled-jsx-${p}-${id}%%*/`
+    .replace(/%%styled-jsx-placeholder-(\d+)%%/g, (_, id) =>
+      `/*%%styled-jsx-placeholder-${id}%%*/`
     )
   let processedCss
   let wait = true
@@ -24,7 +24,7 @@ module.exports = (css, settings) => {
   }
 
   return processedCss
-    .replace(/\/\*%%styled-jsx-(expression|placeholder)-(\d+)%%\*\//g, (_, p, id) =>
-      `%%styled-jsx-${p}-${id}%%`
+    .replace(/\/\*%%styled-jsx-placeholder-(\d+)%%\*\//g, (_, id) =>
+      `%%styled-jsx-placeholder-${id}%%`
     )
 }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,10 @@ const loopWhile = require('deasync').loopWhile
 const processor = require('./processor')
 
 module.exports = (css, settings) => {
+  const cssWithPlaceholders = css
+    .replace(/%%styled-jsx-(expression|placeholder)-(\d+)%%/g, (_, p, id) =>
+      `/*%%styled-jsx-${p}-${id}%%*/`
+    )
   let processedCss
   let wait = true
 
@@ -10,7 +14,7 @@ module.exports = (css, settings) => {
     wait = false
   }
 
-  processor(css)
+  processor(cssWithPlaceholders)
     .then(resolved)
     .catch(resolved)
   loopWhile(() => wait)
@@ -20,4 +24,7 @@ module.exports = (css, settings) => {
   }
 
   return processedCss
+    .replace(/\/\*%%styled-jsx-(expression|placeholder)-(\d+)%%\*\//g, (_, p, id) =>
+      `%%styled-jsx-${p}-${id}%%`
+    )
 }

--- a/test.js
+++ b/test.js
@@ -9,14 +9,7 @@ describe('styled-jsx-plugin-postcss', () => {
     )
   })
 
-  it('works with "styled-jsx-expression" placeholders', () => {
-    assert.equal(
-      plugin('p { img { display: block } color: %%styled-jsx-expression-0%%; } %%styled-jsx-expression-1%%'),
-      'p { color: %%styled-jsx-expression-0%%; } p img { display: block } %%styled-jsx-expression-1%%'
-    )
-  })
-
-  it('works with "styled-jsx-placeholder" placeholders', () => {
+  it('works with placeholders', () => {
     assert.equal(
       plugin('p { img { display: block } color: %%styled-jsx-placeholder-0%%; } %%styled-jsx-placeholder-1%%'),
       'p { color: %%styled-jsx-placeholder-0%%; } p img { display: block } %%styled-jsx-placeholder-1%%'

--- a/test.js
+++ b/test.js
@@ -9,10 +9,17 @@ describe('styled-jsx-plugin-postcss', () => {
     )
   })
 
-  it('works with expressions placeholders', () => {
+  it('works with "styled-jsx-expression" placeholders', () => {
     assert.equal(
-      plugin('p { img { display: block } color: %%styled-jsx-expression-1%%; }'),
-      'p { color: %%styled-jsx-expression-1%%; } p img { display: block }'
+      plugin('p { img { display: block } color: %%styled-jsx-expression-0%%; } %%styled-jsx-expression-1%%'),
+      'p { color: %%styled-jsx-expression-0%%; } p img { display: block } %%styled-jsx-expression-1%%'
+    )
+  })
+
+  it('works with "styled-jsx-placeholder" placeholders', () => {
+    assert.equal(
+      plugin('p { img { display: block } color: %%styled-jsx-placeholder-0%%; } %%styled-jsx-placeholder-1%%'),
+      'p { color: %%styled-jsx-placeholder-0%%; } p img { display: block } %%styled-jsx-placeholder-1%%'
     )
   })
 


### PR DESCRIPTION
This PR wraps placeholder strings in CSS comments before processing. After the CSS has been processed the placeholders are unwrapped. This is similar to the approach in [styled-jsx-plugin-sass](https://github.com/giuseppeg/styled-jsx-plugin-sass/blob/master/index.js#L4).

This allows the following to be processed:

```
    <style jsx>{`
      div {
        color: red;
        ${style}
      }
    `}</style>
```

Without this change the above code throws `CssSyntaxError: <css input>:3:3: Unknown word`.