### PR TITLE
Fix: deasync compatibility issue with node@9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/giuseppeg/styled-jsx-plugin-postcss#readme",
   "dependencies": {
-    "deasync": "^0.1.10",
+    "deasync": "^0.1.12",
     "postcss": "^6.0.13",
     "postcss-load-plugins": "^2.3.0"
   },


### PR DESCRIPTION
Upgrade deasync to address compatibility issue with node@9.3

https://github.com/abbr/deasync/issues/89