### PR TITLE
fix: throw error only when child process exits with error code

### DIFF
--- a/fixture-postcss-plugin.js
+++ b/fixture-postcss-plugin.js
@@ -1,0 +1,7 @@
+const postcss = require('postcss')
+
+module.exports = postcss.plugin('postcss-fixture', () => (root) => {
+  console.warn('warn')
+  console.error('error')
+  return root
+})

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const { spawnSync } = require('child_process');
-const path = require('path');
+const { spawnSync } = require('child_process')
+const path = require('path')
 
 module.exports = (css, settings) => {
   const cssWithPlaceholders = css
@@ -15,7 +15,7 @@ module.exports = (css, settings) => {
     encoding: 'utf8'
   })
 
-  if (result.stderr) {
+  if (result.status !== 0) {
     if (result.stderr.includes('Invalid PostCSS Plugin')) {
       console.error('Next.js 9 default postcss support uses a non standard postcss config schema https://err.sh/next.js/postcss-shape, you must use the interoperable object-based format instead https://nextjs.org/docs/advanced-features/customizing-postcss-config')
     }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,15 +1,18 @@
+const path = require('path')
+
 module.exports = {
-  "plugins": {
-    "postcss-easy-import": {},
-    "postcss-preset-env": {
-      "browsers": ['last 2 versions', 'ie >= 10'],
-      "features": {
-        "nesting-rules": true,
-        "color-mod-function": {
-          unresolved: 'warn'
-        }
-      }
+  plugins: {
+    'postcss-easy-import': {},
+    'postcss-preset-env': {
+      browsers: ['last 2 versions', 'ie >= 10'],
+      features: {
+        'nesting-rules': true,
+        'color-mod-function': {
+          unresolved: 'warn',
+        },
+      },
     },
-    "postcss-spiffing": {}
-  }
+    'postcss-spiffing': {},
+    [path.resolve(__dirname, './fixture-postcss-plugin.js')]: {}
+  },
 }


### PR DESCRIPTION
Fix #40

Throw error only when child process exits with error code. Created `fixture-postcss-plugin.js` postcss plugins that logs to stderr, previously this was making tests to fail, with this fix logging inside plugins works as expected.