### PR TITLE
Make tailwind working

### DIFF
--- a/processor.js
+++ b/processor.js
@@ -15,6 +15,6 @@ module.exports = function processor(src, options) {
   loaderPromises[options.path || 'auto'] = loaderPromise
 
   return loaderPromise
-    .then((plugins) => postcss(plugins).process(src, { from: false }))
+    .then((plugins) => postcss(plugins).process(src, { from: options.babel.filename, map: false }))
     .then((result) => result.css)
 }

--- a/processor.js
+++ b/processor.js
@@ -3,6 +3,9 @@ const loader = require('postcss-load-config')
 
 const loaderPromises = {}
 
+const safeFilenameFromOptions = options =>
+  (options.babel || {}).filename || "unknown filename"
+
 module.exports = function processor(src, options) {
   options = options || {}
 
@@ -15,6 +18,6 @@ module.exports = function processor(src, options) {
   loaderPromises[options.path || 'auto'] = loaderPromise
 
   return loaderPromise
-    .then((plugins) => postcss(plugins).process(src, { from: options.babel.filename, map: false }))
+    .then((plugins) => postcss(plugins).process(src, { from: safeFilenameFromOptions(options), map: false }))
     .then((result) => result.css)
 }


### PR DESCRIPTION
Before this change using @tailwind directive in styled-jsx component lead to

styled-jsx-plugin-postcss] postcss failed with TypeError [ERR_INVALID_ARG_TYPE]:
The "url" argument must be of type string. Received type boolean (false)

According to postcss documentation (https://postcss.org/api/#processoptions) the
'from' option should be a string of the filename. We should get this filename as
options.babel.filename (See: https://github.com/vercel/styled-jsx#plugin-options).

Since we don't use the source maps they are now disabled as well.